### PR TITLE
Return FALSE for s3exists(NULL).  Resolves #22.

### DIFF
--- a/R/s3exists.R
+++ b/R/s3exists.R
@@ -8,12 +8,13 @@
 
 #' @export
 s3exists <- function(name, .path = s3path(), ...) {
+  if (is.null(name)) return(FALSE)  # issue #22
   s3key <- paste(.path, name, sep = '')
   s3key <- gsub('/$', '', s3key) # strip terminal /
   if (!grepl('^s3://', s3key)) stop("s3 paths must begin with \"s3://\"")
   s3cmd <- paste('s3cmd ls', s3key)
-  results <- system(s3cmd, intern=TRUE)
-  sum(grepl(paste(s3key, '(/[0-9A-Za-z]+)*/?$', sep=''), results)) > 0
+  results <- system(s3cmd, intern = TRUE)
+  sum(grepl(paste(s3key, '(/[0-9A-Za-z]+)*/?$', sep = ''), results)) > 0
 }
 
 


### PR DESCRIPTION
When `name` is NULL, `s3key` is identical to `s3path()`, which usually exists.  So the easiest solution is just to return FALSE.