### PR TITLE
Add a trailing slash to path if it is not present

### DIFF
--- a/R/s3read.r
+++ b/R/s3read.r
@@ -17,6 +17,9 @@
 s3read <- function(name = NULL, .path = s3path(), cache = TRUE, ...) { 
   if (is.null(name)) name <- grab_latest_file_in_s3_dir(.path)
   s3key <- paste(.path, name, sep = '')
+
+  if (substr(.path, nchar(.path), nchar(.path)) != "/") { .path <- paste0(.path, "/") }
+
   if (!isTRUE(cache) || is.null(getOption('s3mpi.cache'))) {
     value <- s3.get(s3key, ...)
   } else if (is.not_cached(value <- s3cache(s3key))) {


### PR DESCRIPTION
Not remembering to add the trailing slash to `.path` is a top error I make all the time, and it is annoying.  This should fix the issue.

**Notably, however, this package does not have tests** so we should add tests to this package prior to merging in new PRs...