### PR TITLE
Add put exists check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: R message passing interface using S3 storage
 URL: https://github.com/robertzk/s3mpi
 BugReports: https://github.com/robertzk/s3mpi/issues
 Description: Easily pass objects like lists or dataframes between consoles.
-Version: 0.2.19
+Version: 0.2.20
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski", email = "technoguyrob@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Version 0.2.19
 
+* Workaround for the silent but oh-so-deadly sporadic failure of s3cmd's put.
+  By default we now check for the existence of the object when issuing a put,
+  with the option to retry a number of times.
+
+# Version 0.2.19
+
 * Keep AWS.tools on a remote.
 
 # Version 0.2.18

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# Version 0.2.19
+# Version 0.2.20
 
 * Workaround for the silent but oh-so-deadly sporadic failure of s3cmd's put.
   By default we now check for the existence of the object when issuing a put,

--- a/R/s3.put.R
+++ b/R/s3.put.R
@@ -33,5 +33,3 @@ s3.put <- function (x, path, bucket.location = "US", verbose = FALSE,
     }
   }
 }
-
-

--- a/R/s3.put.R
+++ b/R/s3.put.R
@@ -26,8 +26,7 @@ s3.put <- function (x, path, bucket.location = "US", verbose = FALSE,
   system2(s3cmd(), s3.cmd, stdout = TRUE)
   if (check_exists) {
     retry_count <- 0
-    while (!s3exists(path, bucket.location = bucket.location, verbose = verbose,
-      debug = debug) && retry_count < num_retries) {
+    while (!s3exists(name = bucket.location, path = path) && retry_count < num_retries) {
         system2(s3cmd(), s3.cmd, stdout = TRUE)
         retry_count <- retry_count + 1
     }

--- a/R/s3.put.R
+++ b/R/s3.put.R
@@ -25,10 +25,6 @@ s3.put <- function (x, path, bucket.location = "US", verbose = FALSE,
 
   system2(s3cmd(), s3.cmd, stdout = TRUE)
   if (check_exists) {
-    exists.cmd <- paste("ls", paste0('"', path, '"'), ifelse(encrypt,
-      "--encrypt", ""), paste("--bucket-location", bucket.location),
-      ifelse(verbose, "--verbose --progress", "--no-progress"), ifelse(debug,
-        "--debug", ""), '--check-md5')
     retry_count <- 0
     while (!s3exists(path, bucket.location = bucket.location, verbose = verbose,
       debug = debug) && retry_count < num_retries) {

--- a/R/s3.put.R
+++ b/R/s3.put.R
@@ -3,7 +3,8 @@
 #' @param x ANY. R object to store to S3.
 #' @rdname s3.get
 s3.put <- function (x, path, bucket.location = "US", verbose = FALSE,
-                    debug = FALSE, encrypt = FALSE) {
+                    debug = FALSE, encrypt = FALSE, check_exists = TRUE,
+                    num_retries = 3) {
   ## This inappropriately-named function actually checks existence
   ## of a *path*, not a bucket.
   AWS.tools:::check.bucket(path)

--- a/R/s3.put.R
+++ b/R/s3.put.R
@@ -28,12 +28,14 @@ s3.put <- function (x, path, name, bucket.location = "US", verbose = FALSE,
 }
 
 run_system_put <- function(path, name, s3.cmd, check_exists, num_retries) {
-  system2(s3cmd(), s3.cmd, stdout = TRUE)
-  if (isTRUE(check_exists)) {
-    if (!s3exists(name, path) && num_retries > 0) {
-      Recall(path, name, s3.cmd, check_exists, num_retries - 1)
-    } else if (num_retries <= 0) {
+  ret <- system2(s3cmd(), s3.cmd, stdout = TRUE)
+  if (isTRUE(check_exists) && !s3exists(name, path)) {
+    if (num_retries > 0) {
+      do.call(Recall, `$<-`(as.list(match.call()[-1]), "num_retries", num_retries - 1))
+    } else {
       stop("Object could not be successfully stored.")
     }
+  } else {
+    ret
   }
 }

--- a/R/s3.put.R
+++ b/R/s3.put.R
@@ -26,7 +26,7 @@ s3.put <- function (x, path, bucket.location = "US", verbose = FALSE,
   system2(s3cmd(), s3.cmd, stdout = TRUE)
   if (check_exists) {
     retry_count <- 0
-    while (!s3exists(name = bucket.location, path = path) && retry_count < num_retries) {
+    while (!s3exists(path) && retry_count < num_retries) {
         system2(s3cmd(), s3.cmd, stdout = TRUE)
         retry_count <- retry_count + 1
     }

--- a/R/s3.put.R
+++ b/R/s3.put.R
@@ -24,4 +24,18 @@ s3.put <- function (x, path, bucket.location = "US", verbose = FALSE,
           "--debug", ""), '--check-md5')
 
   system2(s3cmd(), s3.cmd, stdout = TRUE)
+  if (check_exists) {
+    exists.cmd <- paste("ls", paste0('"', path, '"'), ifelse(encrypt,
+      "--encrypt", ""), paste("--bucket-location", bucket.location),
+      ifelse(verbose, "--verbose --progress", "--no-progress"), ifelse(debug,
+        "--debug", ""), '--check-md5')
+    retry_count <- 0
+    while (!s3exists(path, bucket.location = bucket.location, verbose = verbose,
+      debug = debug) && retry_count < num_retries) {
+        system2(s3cmd(), s3.cmd, stdout = TRUE)
+        retry_count <- retry_count + 1
+    }
+  }
 }
+
+

--- a/R/s3store.r
+++ b/R/s3store.r
@@ -43,7 +43,7 @@ s3store <- function(obj, name = NULL, path = s3path(), safe = FALSE, ...) {
   }
 
   obj4save <- s3normalize(obj, FALSE)
-  s3.put(obj4save, s3key, ...)
+  s3.put(obj4save, path, name, ...)
 
   if (!is.null(getOption("s3mpi.cache"))) {
     s3cache(s3key, obj4save)

--- a/tests/testthat/test-s3store.R
+++ b/tests/testthat/test-s3store.R
@@ -13,6 +13,7 @@ local({
 
   test_that("it can store raw values if the caching layer is disabled", {
     map <- list2env(list("s3://test/key" = NULL))
+    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
     testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
       s3store("value", "key")
@@ -20,12 +21,13 @@ local({
       map$`s3://test/key` <- "new_value"
       # Make sure we are not caching.
       expect_equal(s3read("key", cache = FALSE), "new_value")
-    })})
+    })})})
   })
 
   test_that("it can store values if the caching layer is enabled", {
     map <- list2env(list("s3://test/key" = NULL))
     map2 <- new.env(parent = map)
+    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map2[[..1]], {
     testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map2[[paste0(..2, ..3)]] <- ..1, {
       s3store("value", "key")
@@ -33,12 +35,13 @@ local({
       map$`s3://test/key` <- "new_value"
       # Make sure we are not caching.
       expect_equal(s3read("key"), "value")
-    })})
+    })})})
   })
 
   test_that("it denormalizes", {
     map <- list2env(list("s3://test/key" = "value"))
 
+    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3normalize",  function(a, b) { map$norm <- missing(b); a }, {
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
     testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
@@ -46,17 +49,35 @@ local({
       expect_false(map$norm)
       s3store(new.env(), "key2")
       expect_true(map$norm)
-    })})})
+    })})})})
   })
 
   test_that("it can pick up missing key", {
     map <- list2env(list("s3://test/key" = NULL))
+    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
     testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
       key <- "value"
       s3store(key)
       expect_equal(s3read("key"), "value")
-    })})
+    })})})
+  })
+
+  test_that("it produces an error when the object isn't found with an s3exists following the s3.put", {
+    map <- list2env(list("s3://test/key" = NULL))
+    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) FALSE, {
+    testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
+      expect_error(s3store("value", "key"))
+    })})})
+  })
+  test_that("it does not produce an error when the object is found with an s3exists following the s3.put", {
+    map <- list2env(list("s3://test/key" = NULL))
+    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
+    testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
+      expect_error(s3store("value", "key"), NA)
+    })})})
   })
 })
 

--- a/tests/testthat/test-s3store.R
+++ b/tests/testthat/test-s3store.R
@@ -13,69 +13,66 @@ local({
 
   test_that("it can store raw values if the caching layer is disabled", {
     map <- list2env(list("s3://test/key" = NULL))
-    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
-    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...) map[[paste0(..2, ..3)]] <- ..1, {
       s3store("value", "key")
       expect_equal(s3read("key"), "value")
       map$`s3://test/key` <- "new_value"
       # Make sure we are not caching.
       expect_equal(s3read("key", cache = FALSE), "new_value")
-    })})})
+    })})
   })
 
   test_that("it can store values if the caching layer is enabled", {
     map <- list2env(list("s3://test/key" = NULL))
     map2 <- new.env(parent = map)
-    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map2[[..1]], {
-    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map2[[paste0(..2, ..3)]] <- ..1, {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...) map2[[paste0(..2, ..3)]] <- ..1, {
       s3store("value", "key")
       expect_equal(s3read("key"), "value")
       map$`s3://test/key` <- "new_value"
       # Make sure we are not caching.
       expect_equal(s3read("key"), "value")
-    })})})
+    })})
   })
 
   test_that("it denormalizes", {
     map <- list2env(list("s3://test/key" = "value"))
 
-    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3normalize",  function(a, b) { map$norm <- missing(b); a }, {
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
-    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...) map[[paste0(..2, ..3)]] <- ..1, {
       s3store("value", "key")
       expect_false(map$norm)
       s3store(new.env(), "key2")
       expect_true(map$norm)
-    })})})})
+    })})})
   })
 
   test_that("it can pick up missing key", {
     map <- list2env(list("s3://test/key" = NULL))
-    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
-    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...) map[[paste0(..2, ..3)]] <- ..1, {
       key <- "value"
       s3store(key)
       expect_equal(s3read("key"), "value")
-    })})})
+    })})
   })
 
   test_that("it produces an error when the object isn't found with an s3exists following the s3.put", {
     map <- list2env(list("s3://test/key" = NULL))
-    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) FALSE, {
-    testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
-    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
+    testthatsomemore::package_stub("AWS.tools", "check.bucket",  function(...) TRUE, {
+    testthatsomemore::package_stub("base", "system",  function(...) TRUE, {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...) run_system_put(..2, ..3, "", TRUE, 0), {
       expect_error(s3store("value", "key"))
     })})})
   })
+
   test_that("it does not produce an error when the object is found with an s3exists following the s3.put", {
     map <- list2env(list("s3://test/key" = NULL))
-    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
-    testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
-    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
+    testthatsomemore::package_stub("AWS.tools", "check.bucket",  function(...) TRUE, {
+    testthatsomemore::package_stub("base", "system",  function(...) TRUE, {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...) run_system_put(..2, ..3, "", TRUE, 0), {
       expect_error(s3store("value", "key"), NA)
     })})})
   })

--- a/tests/testthat/test-s3store.R
+++ b/tests/testthat/test-s3store.R
@@ -14,7 +14,7 @@ local({
   test_that("it can store raw values if the caching layer is disabled", {
     map <- list2env(list("s3://test/key" = NULL))
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
-    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[..2]] <- ..1, {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
       s3store("value", "key")
       expect_equal(s3read("key"), "value")
       map$`s3://test/key` <- "new_value"
@@ -27,7 +27,7 @@ local({
     map <- list2env(list("s3://test/key" = NULL))
     map2 <- new.env(parent = map)
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map2[[..1]], {
-    testthatsomemore::package_stub("s3mpi", "s3.put", function(...) map2[[..2]] <- ..1, {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
       s3store("value", "key")
       expect_equal(s3read("key"), "value")
       map$`s3://test/key` <- "new_value"
@@ -41,7 +41,7 @@ local({
 
     testthatsomemore::package_stub("s3mpi", "s3normalize",  function(a, b) { map$norm <- missing(b); a }, {
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
-    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[..2]] <- ..1, {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
       s3store("value", "key")
       expect_false(map$norm)
       s3store(new.env(), "key2")
@@ -52,7 +52,7 @@ local({
   test_that("it can pick up missing key", {
     map <- list2env(list("s3://test/key" = NULL))
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map[[..1]], {
-    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[..2]] <- ..1, {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
       key <- "value"
       s3store(key)
       expect_equal(s3read("key"), "value")

--- a/tests/testthat/test-s3store.R
+++ b/tests/testthat/test-s3store.R
@@ -27,7 +27,7 @@ local({
     map <- list2env(list("s3://test/key" = NULL))
     map2 <- new.env(parent = map)
     testthatsomemore::package_stub("s3mpi", "s3.get",  function(...) map2[[..1]], {
-    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map[[paste0(..2, ..3)]] <- ..1, {
+    testthatsomemore::package_stub("s3mpi", "s3.put", function(...)  map2[[paste0(..2, ..3)]] <- ..1, {
       s3store("value", "key")
       expect_equal(s3read("key"), "value")
       map$`s3://test/key` <- "new_value"

--- a/tests/testthat/test-s3store.R
+++ b/tests/testthat/test-s3store.R
@@ -61,22 +61,20 @@ local({
 
   test_that("it produces an error when the object isn't found with an s3exists following the s3.put", {
     map <- list2env(list("s3://test/key" = NULL))
-    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
-    testthatsomemore::package_stub("AWS.tools", "check.bucket",  function(...) NULL, {
     testthatsomemore::package_stub("base", "system",  function(...) TRUE, {
+    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3.put", function(...) run_system_put(..2, ..3, "", TRUE, 0), {
       expect_error(s3store("value", "key"))
-    })})})})
+    })})})
   })
 
   test_that("it does not produce an error when the object is found with an s3exists following the s3.put", {
     map <- list2env(list("s3://test/key" = NULL))
-    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) FALSE, {
-    testthatsomemore::package_stub("AWS.tools", "check.bucket",  function(...) NULL, {
     testthatsomemore::package_stub("base", "system",  function(...) TRUE, {
+    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) FALSE, {
     testthatsomemore::package_stub("s3mpi", "s3.put", function(...) run_system_put(..2, ..3, "", TRUE, 0), {
       expect_error(s3store("value", "key"), NA)
-    })})})})
+    })})})
   })
 })
 

--- a/tests/testthat/test-s3store.R
+++ b/tests/testthat/test-s3store.R
@@ -61,7 +61,7 @@ local({
 
   test_that("it produces an error when the object isn't found with an s3exists following the s3.put", {
     map <- list2env(list("s3://test/key" = NULL))
-    testthatsomemore::package_stub("base", "system",  function(...) TRUE, {
+    testthatsomemore::package_stub("base", "system2",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3.put", function(...) run_system_put(..2, ..3, "", TRUE, 0), {
       expect_error(s3store("value", "key"))
@@ -70,7 +70,7 @@ local({
 
   test_that("it does not produce an error when the object is found with an s3exists following the s3.put", {
     map <- list2env(list("s3://test/key" = NULL))
-    testthatsomemore::package_stub("base", "system",  function(...) TRUE, {
+    testthatsomemore::package_stub("base", "system2",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) FALSE, {
     testthatsomemore::package_stub("s3mpi", "s3.put", function(...) run_system_put(..2, ..3, "", TRUE, 0), {
       expect_error(s3store("value", "key"), NA)

--- a/tests/testthat/test-s3store.R
+++ b/tests/testthat/test-s3store.R
@@ -61,20 +61,22 @@ local({
 
   test_that("it produces an error when the object isn't found with an s3exists following the s3.put", {
     map <- list2env(list("s3://test/key" = NULL))
-    testthatsomemore::package_stub("AWS.tools", "check.bucket",  function(...) TRUE, {
+    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
+    testthatsomemore::package_stub("AWS.tools", "check.bucket",  function(...) NULL, {
     testthatsomemore::package_stub("base", "system",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3.put", function(...) run_system_put(..2, ..3, "", TRUE, 0), {
       expect_error(s3store("value", "key"))
-    })})})
+    })})})})
   })
 
   test_that("it does not produce an error when the object is found with an s3exists following the s3.put", {
     map <- list2env(list("s3://test/key" = NULL))
-    testthatsomemore::package_stub("AWS.tools", "check.bucket",  function(...) TRUE, {
+    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) FALSE, {
+    testthatsomemore::package_stub("AWS.tools", "check.bucket",  function(...) NULL, {
     testthatsomemore::package_stub("base", "system",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3.put", function(...) run_system_put(..2, ..3, "", TRUE, 0), {
       expect_error(s3store("value", "key"), NA)
-    })})})
+    })})})})
   })
 })
 

--- a/tests/testthat/test-s3store.R
+++ b/tests/testthat/test-s3store.R
@@ -62,7 +62,7 @@ local({
   test_that("it produces an error when the object isn't found with an s3exists following the s3.put", {
     map <- list2env(list("s3://test/key" = NULL))
     testthatsomemore::package_stub("base", "system2",  function(...) TRUE, {
-    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
+    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) FALSE, {
     testthatsomemore::package_stub("s3mpi", "s3.put", function(...) run_system_put(..2, ..3, "", TRUE, 0), {
       expect_error(s3store("value", "key"))
     })})})
@@ -71,7 +71,7 @@ local({
   test_that("it does not produce an error when the object is found with an s3exists following the s3.put", {
     map <- list2env(list("s3://test/key" = NULL))
     testthatsomemore::package_stub("base", "system2",  function(...) TRUE, {
-    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) FALSE, {
+    testthatsomemore::package_stub("s3mpi", "s3exists",  function(...) TRUE, {
     testthatsomemore::package_stub("s3mpi", "s3.put", function(...) run_system_put(..2, ..3, "", TRUE, 0), {
       expect_error(s3store("value", "key"), NA)
     })})})


### PR DESCRIPTION
This is just a quick way of addressing https://github.com/robertzk/s3mpi/issues/46

It adds an existence check to s3.put to ensure that the object was correctly uploaded.  This could also be done by checking for the exit code of 2, but then that might change if people change their system s3cmd.  This doesn't seem too unreasonable.  Defaults to checking for existence, but obviously it doesn't have to.  Has a retry loop, but we could remove that and just error out on a bad put (or I could keep the retry logic and error out if the final put is unsuccessful).  Haven't tested it at all yet.