### PR TITLE
Fix S3 last_updated issue.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: R message passing interface using S3 storage
 URL: https://github.com/robertzk/s3mpi
 BugReports: https://github.com/robertzk/s3mpi/issues
 Description: Easily pass objects like lists or dataframes between consoles.
-Version: 0.2.20
+Version: 0.2.21
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski", email = "technoguyrob@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * Fixed an issue where reading files that have the same prefix as another file
   on the S3 bucket generates a warning.
+* Fix a more serious problem where writing and reading within the same minute
+  produces incorrect results due to the s3cmd utility having *minute*-level
+  rather than second-level granularity.
 
 # Version 0.2.20
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Version 0.2.21
+
+* Fixed an issue where reading files that have the same prefix as another file
+  on the S3 bucket generates a warning.
+
 # Version 0.2.20
 
 * Workaround for the silent but oh-so-deadly sporadic failure of s3cmd's put.

--- a/R/s3.get.R
+++ b/R/s3.get.R
@@ -59,7 +59,7 @@ s3.get <- function (path, bucket.location = "US", verbose = FALSE, debug = FALSE
     last_cached <- s3LRUcache()$last_accessed(path) # assumes a POSIXct object
 
     # Check time on s3 remote's copy
-    s3.cmd <- paste("ls ", path, "| awk '{print $1\" \"$2}' ")
+    s3.cmd <- paste("ls ", path, "| head -n 1 | awk '{print $1\" \"$2}' ")
     last_updated <- as.POSIXct(system2(s3cmd(), s3.cmd, stdout = TRUE), tz = "GMT")
 
     # Update the cache if remote is newer.

--- a/R/s3.get.R
+++ b/R/s3.get.R
@@ -63,7 +63,7 @@ s3.get <- function (path, bucket.location = "US", verbose = FALSE, debug = FALSE
     last_updated <- as.POSIXct(system2(s3cmd(), s3.cmd, stdout = TRUE), tz = "GMT")
 
     # Update the cache if remote is newer by at least a minute.
-    if (in_later_minute(last_updated, last_cached)) {
+    if (in_earlier_minute(last_cached, last_updated)) {
       ans <- fetch()
       s3LRUcache()$set(path, ans)
     } else {

--- a/R/s3.get.R
+++ b/R/s3.get.R
@@ -62,8 +62,8 @@ s3.get <- function (path, bucket.location = "US", verbose = FALSE, debug = FALSE
     s3.cmd <- paste("ls ", path, "| head -n 1 | awk '{print $1\" \"$2}' ")
     last_updated <- as.POSIXct(system2(s3cmd(), s3.cmd, stdout = TRUE), tz = "GMT")
 
-    # Update the cache if remote is newer.
-    if (last_updated > last_cached) {
+    # Update the cache if remote is newer by at least a minute.
+    if (in_later_minute(last_updated, last_cached)) {
       ans <- fetch()
       s3LRUcache()$set(path, ans)
     } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -78,3 +78,16 @@ s3LRUcache <- function() {
     .s3mpienv$lrucache
   }
 }
+
+## The `s3cmd ls` utility produces updated_at times at the granularity of minutes. 
+## If we store an object within the same minute, it will be incorrectly read from
+## the cache unless we check that the updated_at occurs at a later *minute* than
+## the cached_at.
+in_later_minute <- function(time1, time2) {
+  round_to_latest_minute(time1) > round_to_latest_minute(time2)
+}
+
+round_to_latest_minute <- function(time) {
+  as.POSIXct(format(time[1L], "%Y-%m-%d %H:%M:00 %Z", tz = "GMT"))
+}
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -83,8 +83,8 @@ s3LRUcache <- function() {
 ## If we store an object within the same minute, it will be incorrectly read from
 ## the cache unless we check that the updated_at occurs at a later *minute* than
 ## the cached_at.
-in_later_minute <- function(time1, time2) {
-  round_to_latest_minute(time1) > round_to_latest_minute(time2)
+in_earlier_minute <- function(time1, time2) {
+  round_to_latest_minute(time1) <= round_to_latest_minute(time2)
 }
 
 round_to_latest_minute <- function(time) {


### PR DESCRIPTION
* `s3cmd ls s3://foo/bar` will list multiple files if there are keys `bar1`, `bar-baz`, etc. Fix a warning related to this.

* Since `s3cmd ls` provides granularity at the minute-level instead of the second-level, it is only safe to use the cache if it is a minute later than the `last_updated` given by the `s3cmd ls` command.

