### PR TITLE
bugfix in `s3cmd_put_command`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: R message passing interface using S3 storage
 URL: https://github.com/robertzk/s3mpi
 BugReports: https://github.com/robertzk/s3mpi/issues
 Description: Easily pass objects like lists or dataframes between consoles.
-Version: 0.2.33
+Version: 0.2.34
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski", email = "technoguyrob@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
-# Version 0.2.33
+# Version 0.2.33-4
 
 * Other fixes for s4cmd.
 
 # Version 0.2.32
+
 * allow choice of storage format in `s3read` and `s3store`. Defaults to `RDS`,
   and now you can chooose `CSV` or `table` for data frames.
 

--- a/R/s3.put.R
+++ b/R/s3.put.R
@@ -64,7 +64,7 @@ run_system_put <- function(path, name, s3.cmd, check_exists, num_retries, backof
 
 s3cmd_put_command <- function(s3key, file, bucket_flag, debug) {
   if (use_legacy_api()) {
-    paste("put", x.serialized, paste0('"', s3key, '"'),
+    paste("put", file, paste0('"', s3key, '"'),
           bucket_location_to_flag(bucket.location),
           ifelse(debug, "--debug", ""), "--force")
   } else {

--- a/R/s3.put.R
+++ b/R/s3.put.R
@@ -65,8 +65,7 @@ run_system_put <- function(path, name, s3.cmd, check_exists, num_retries, backof
 s3cmd_put_command <- function(s3key, file, bucket_flag, debug) {
   if (use_legacy_api()) {
     paste("put", file, paste0('"', s3key, '"'),
-          bucket_location_to_flag(bucket.location),
-          ifelse(debug, "--debug", ""), "--force")
+          bucket_flag, ifelse(debug, "--debug", ""), "--force")
   } else {
     paste0("s3 cp ", file, " ", s3key)
   }


### PR DESCRIPTION
Addresses the following error message:
```
> options("s3mpi.legacy_api" = TRUE)
> s3mpi::s3store(7, "abel/testing_s3mpi", "s3://mys3bucket")
Error in paste("put", x.serialized, paste0("\"", s3key, "\""), bucket_location_to_flag(bucket.location),  :
  object 'x.serialized' not found
```